### PR TITLE
Added error listener to taskGroup

### DIFF
--- a/src/lib/taskgroup.coffee
+++ b/src/lib/taskgroup.coffee
@@ -244,6 +244,9 @@ class TaskGroup extends EventEmitter
 		# Give setConfig enough chance to fire
 		process.nextTick(@fire.bind(@))
 
+		# Handle errors
+		@on('error', (err) -> me.exit(err))
+
 		# Handle item completion
 		@on('item.complete', @itemCompletionCallback.bind(@))
 


### PR DESCRIPTION
Fix relates to an error discovered with docpad issue bevry/docpad#692

I haven't able to create tests for this condition however the current tests still pass with this change.
