### PR TITLE
ensures setImmediate is not overridden by coffee-script generated local variable

### DIFF
--- a/src/lib/taskgroup.coffee
+++ b/src/lib/taskgroup.coffee
@@ -1,5 +1,5 @@
 # Import
-`setImmediate = setImmediate || process.nextTick`  # node 0.8 b/c
+`var setImmediate = setImmediate; if (!setImmediate) setImmediate=process.nextTick`  # node 0.8 b/c
 ambi = require('ambi')
 events = require('events')
 domain =


### PR DESCRIPTION
Because coffee-script conveniently generates local variable statements it was overriding `setImmediate` with `var setImmediate`, so therefore taskGroup would always use process.nextTick regardless..
